### PR TITLE
✨ feat: 어드민 수강신청 일괄 승인 mock api 구현

### DIFF
--- a/apps/users/serializers/admin_enrollments_serializers.py
+++ b/apps/users/serializers/admin_enrollments_serializers.py
@@ -1,0 +1,33 @@
+from typing import Any, List, Type
+
+from rest_framework import serializers
+
+from apps.users.models import StudentEnrollmentRequest
+
+
+# 요청용 시리얼라이저
+class EnrollmentRequestIdsSerializer(serializers.Serializer[Any]):
+    ids = serializers.ListField(  # ✅ ListField는 제네릭 X
+        child=serializers.IntegerField(), help_text="승인할 수강생 등록 신청의 ID 리스트"
+    )
+
+
+# 승인 응답 시리얼라이저
+class ApprovalResponseSerializer(serializers.Serializer[Any]):
+    approved_ids = serializers.ListField(child=serializers.IntegerField(), help_text="mock 승인된 수강신청 ID 목록")
+    message = serializers.CharField(help_text="처리 결과 요약 메시지")
+
+
+# 수강생 등록 정보 시리얼라이저
+class EnrollmentSerializer(serializers.ModelSerializer[Any]):
+    class Meta:
+        model = StudentEnrollmentRequest
+        fields = [
+            "id",
+            "user_id",
+            "generation_id",
+            "status",
+            "accepted_at",
+            "created_at",
+            "updated_at",
+        ]

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from apps.users.views.admin_enrollments_views import AdminApproveEnrollmentsView
 from apps.users.views.admin_user_views import (
     AdminUserDeleteView,
     AdminUserDetailView,
@@ -14,4 +15,9 @@ urlpatterns = [
     path("admin/users/<int:user_id>/update/", AdminUserUpdateView.as_view(), name="admin-user-update"),
     path("admin/users/<int:user_id>/delete/", AdminUserDeleteView.as_view(), name="admin-user-delete"),
     path("admin/users/<int:user_id>/role/", AdminUserRoleUpdateView.as_view(), name="admin-user-role-update"),
+    path(
+        "admin/users/student-enrollments/approve/",
+        AdminApproveEnrollmentsView.as_view(),
+        name="admin-student-enrollments-approve",
+    ),
 ]

--- a/apps/users/views/admin_enrollments_views.py
+++ b/apps/users/views/admin_enrollments_views.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, List
+
+from django.utils import timezone
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.models import StudentEnrollmentRequest
+from apps.users.serializers.admin_enrollments_serializers import (
+    ApprovalResponseSerializer,
+    EnrollmentRequestIdsSerializer,
+)
+
+
+class AdminApproveEnrollmentsView(APIView):
+    permission_classes = [AllowAny]
+    serializer_class = ApprovalResponseSerializer
+
+    @extend_schema(
+        request=EnrollmentRequestIdsSerializer,
+        responses={200: ApprovalResponseSerializer},
+        summary="어드민 수강신청 일괄 승인",
+        description="선택한 ID 중 'PENDING' 상태인 수강신청을 승인합니다.",
+        tags=["Admin - 수강 신청"],
+    )
+    def post(self, request: Request) -> Response:
+        serializer = EnrollmentRequestIdsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        ids: List[int] = serializer.validated_data["ids"]
+
+        now = timezone.now()
+
+        mock_enrollment: List[StudentEnrollmentRequest] = [
+            StudentEnrollmentRequest(
+                id=id_,
+                user_id=0,
+                generation_id=0,
+                status=StudentEnrollmentRequest.EnrollmentStatus.APPROVED,
+                accepted_at=now,
+                created_at=now,
+                updated_at=now,
+            )
+            for id_ in ids
+        ]
+
+        # 응답 메시지 및 serializer 구성
+        message = f"{len(mock_enrollment)}건의 수강신청을 승인했습니다."
+        response_data = {"approved_ids": [obj.id for obj in mock_enrollment], "message": message}
+
+        response_serializer = ApprovalResponseSerializer(response_data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
어드민 수강신청 일괄 승인 view 및 serializer 생성

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- 어드민 수강신청 일괄 승인 view 생성
- 어드민 수강신청 일괄 승인 serializer 생성



## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
