### PR TITLE
✨  feat     : (Admin) 수강생 등록 신청 반려  Mock API 작성

### DIFF
--- a/apps/users/serializers/admin_enrollments_rejection_serializers.py
+++ b/apps/users/serializers/admin_enrollments_rejection_serializers.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+# 요청
+class MockEnrollmentSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField(min_value=1, help_text="수강 신청 ID")
+    status = serializers.ChoiceField(
+        choices=["PENDING", "APPROVED", "REJECTED"], help_text="현재 상태 (PENDING, APPROVED, REJECTED)"
+    )
+
+
+class RejectEnrollmentRequestSerializer(serializers.Serializer[Any]):
+    enrollments = MockEnrollmentSerializer(many=True, help_text="반려할 수강신청 ID + 상태 목록")
+
+
+# 반려 응답
+class RejectionResponseSerializer(serializers.Serializer[Any]):
+    rejected_ids = serializers.ListField(child=serializers.IntegerField(), help_text="반려 처리된 수강신청 ID")
+    skipped_ids = serializers.ListField(child=serializers.IntegerField(), help_text="이미 반려되어 건너뛴 ID")
+    downgraded_user_ids = serializers.ListField(
+        child=serializers.IntegerField(), help_text="권한이 General로 롤백된 ID"
+    )
+    deleted_permission_ids = serializers.ListField(child=serializers.IntegerField(), help_text="수강 권한 삭제된 ID")
+    message = serializers.CharField(help_text="처리 결과 메시지")
+    mock_processed_at = serializers.DateTimeField(help_text="Mock 처리 일시")

--- a/apps/users/serializers/admin_enrollments_rejection_serializers.py
+++ b/apps/users/serializers/admin_enrollments_rejection_serializers.py
@@ -2,12 +2,14 @@ from typing import Any
 
 from rest_framework import serializers
 
+from apps.users.models import StudentEnrollmentRequest
+
 
 # 요청
 class MockEnrollmentSerializer(serializers.Serializer[Any]):
     id = serializers.IntegerField(min_value=1, help_text="수강 신청 ID")
     status = serializers.ChoiceField(
-        choices=["PENDING", "APPROVED", "REJECTED"], help_text="현재 상태 (PENDING, APPROVED, REJECTED)"
+        choices=StudentEnrollmentRequest.EnrollmentStatus.choices, help_text="현재 상태 (PENDING, APPROVED, REJECTED)"
     )
 
 

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -7,6 +7,9 @@ from apps.users.views.admin_dashboard_views import (
     AdminWithdrawalReasonTrendView,
     AdminWithdrawTrendView,
 )
+from apps.users.views.admin_enrollments_rejection_views import (
+    RejectEnrollmentRequestView,
+)
 from apps.users.views.admin_enrollments_views import AdminApproveEnrollmentsView
 from apps.users.views.admin_user_views import (
     AdminUserDeleteView,
@@ -45,6 +48,7 @@ urlpatterns = [
     path("profile/", UserProfileView.as_view(), name="user-profile"),
     path("profile/update/", UserProfileUpdateView.as_view(), name="user-profile-update"),
     path("profile/nickname-check/", NicknameCheckView.as_view(), name="nickname-check"),
+    # admin 유저 관리
     path("admin/users/", AdminUserListView.as_view(), name="admin-user-list"),
     path("admin/users/<int:user_id>/", AdminUserDetailView.as_view(), name="admin-user-detail"),
     path("admin/users/<int:user_id>/update/", AdminUserUpdateView.as_view(), name="admin-user-update"),
@@ -76,5 +80,10 @@ urlpatterns = [
         "admin/users/student-enrollments/approve/",
         AdminApproveEnrollmentsView.as_view(),
         name="admin-student-enrollments-approve",
+    ),
+    path(
+        "admin/users/student-enrollments/reject/",
+        RejectEnrollmentRequestView.as_view(),
+        name="admin-student-enrollments-reject",
     ),
 ]

--- a/apps/users/views/admin_enrollments_rejection_views.py
+++ b/apps/users/views/admin_enrollments_rejection_views.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.serializers.admin_enrollments_rejection_serializers import (
+    RejectEnrollmentRequestSerializer,
+    RejectionResponseSerializer,
+)
+
+
+class RejectEnrollmentRequestView(APIView):
+    permission_classes = [AllowAny]
+
+    # pending, approved 상태만 반려
+    # rejected 상태이면 스킵
+    # approved 상태였는데 반려시킨거면 수강생 권한 general로 롤백, 권한삭제처리
+
+    @extend_schema(
+        request=RejectEnrollmentRequestSerializer,
+        description="(Mock) 수강생 등록 신청 반려 API - 승인/대기 상태만 반려, 이미 반려된 항목 제외",
+        tags=["Admin - 수강생 등록 신청 반려"],
+        responses={200: RejectionResponseSerializer},
+    )
+    def post(self, request: Request) -> Response:
+        serializer = RejectEnrollmentRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        enrollments = serializer.validated_data["enrollments"]
+
+        rejected_ids = []
+        skipped_ids = []
+        downgraded_user_ids = []
+        deleted_permission_ids = []
+
+        for enrollment in enrollments:
+            enrollment_id = enrollment["id"]
+            status_value = enrollment["status"]
+
+            if status_value == "REJECTED":
+                skipped_ids.append(enrollment_id)
+            elif status_value == "PENDING":
+                rejected_ids.append(enrollment_id)
+            elif status_value == "APPROVED":
+                rejected_ids.append(enrollment_id)
+                downgraded_user_ids.append(enrollment_id)
+                deleted_permission_ids.append(enrollment_id)
+
+        message = f"{len(rejected_ids)}건 반려 완료. {len(skipped_ids)}건은 이미 반려된 상태입니다."
+
+        response_data = {
+            "message": message,
+            "rejected_ids": rejected_ids,
+            "skipped_ids": skipped_ids,
+            "downgraded_user_ids": downgraded_user_ids,
+            "deleted_permission_ids": deleted_permission_ids,
+            "mock_processed_at": datetime.now(),
+        }
+
+        response_serializer = RejectionResponseSerializer(response_data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/apps/users/views/admin_enrollments_rejection_views.py
+++ b/apps/users/views/admin_enrollments_rejection_views.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.users.models import StudentEnrollmentRequest
 from apps.users.serializers.admin_enrollments_rejection_serializers import (
     RejectEnrollmentRequestSerializer,
     RejectionResponseSerializer,
@@ -36,15 +37,17 @@ class RejectEnrollmentRequestView(APIView):
         downgraded_user_ids = []
         deleted_permission_ids = []
 
+        status_enum = StudentEnrollmentRequest.EnrollmentStatus
+
         for enrollment in enrollments:
             enrollment_id = enrollment["id"]
             status_value = enrollment["status"]
 
-            if status_value == "REJECTED":
+            if status_value == status_enum.REJECTED:
                 skipped_ids.append(enrollment_id)
-            elif status_value == "PENDING":
+            elif status_value == status_enum.PENDING:
                 rejected_ids.append(enrollment_id)
-            elif status_value == "APPROVED":
+            elif status_value == status_enum.APPROVED:
                 rejected_ids.append(enrollment_id)
                 downgraded_user_ids.append(enrollment_id)
                 deleted_permission_ids.append(enrollment_id)


### PR DESCRIPTION
수강생 등록 신청 반려 views, serializers 구현

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 수강생 등록 신청 반려 views, serializers 구현

## 📄 상세 내용
- 관리자(admin) 권한을 가진 유저는 어드민 페이지내에서 수강생 등록 신청 현황을 반려
- [ ] 주요 변경 사항 2
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
