### PR TITLE
✨ feat: 쪽지시험 문제삭제 기능 추가

### DIFF
--- a/apps/tests/serializers/test_question_serializers.py
+++ b/apps/tests/serializers/test_question_serializers.py
@@ -72,8 +72,3 @@ class TestListItemSerializer(serializers.ModelSerializer):  # type: ignore
             "score",
             "correct_count",
         ]
-
-
-# 삭제 응답
-class DeleteResponseSerializer(serializers.Serializer):  # type: ignore
-    detail = serializers.CharField(help_text="에러 메시지 설명")

--- a/apps/tests/serializers/test_question_serializers.py
+++ b/apps/tests/serializers/test_question_serializers.py
@@ -75,5 +75,5 @@ class TestListItemSerializer(serializers.ModelSerializer):  # type: ignore
 
 
 # 삭제 응답
-class ErrorResponseSerializer(serializers.Serializer):  # type: ignore
-    detail = serializers.CharField()
+class DeleteResponseSerializer(serializers.Serializer):  # type: ignore
+    detail = serializers.CharField(help_text="에러 메시지 설명")

--- a/apps/tests/testquestion_permissions.py
+++ b/apps/tests/testquestion_permissions.py
@@ -1,8 +1,0 @@
-from rest_framework.permissions import BasePermission
-
-
-class IsAdminOrStaffByGroup(BasePermission):
-    def has_permission(self, request, view):
-        return (
-            request.user and request.user.groups.filter(name_in=["관리자", "조교", "러닝코치", "운영매니저"]).exists()
-        )

--- a/apps/tests/testquestion_permissions.py
+++ b/apps/tests/testquestion_permissions.py
@@ -1,0 +1,8 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsAdminOrStaffByGroup(BasePermission):
+    def has_permission(self, request, view):
+        return (
+            request.user and request.user.groups.filter(name_in=["관리자", "조교", "러닝코치", "운영매니저"]).exists()
+        )

--- a/apps/tests/urls.py
+++ b/apps/tests/urls.py
@@ -78,6 +78,11 @@ urlpatterns = [
     path("admin/tests/<int:test_id>/", AdminTestDetailAPIView.as_view(), name="test-detail"),
     path("admin/tests/", AdminTestListView.as_view(), name="admin-test-list"),
     path("admin/tests/create", AdminTestCreateAPIView.as_view(), name="test-create"),
+    path("admin/test-questions/", TestQuestionCreateView.as_view(), name="test-question-create"),
+    path(
+        "admin/test-questions/<int:question_id>/", TestQuestionUpdateDeleteView.as_view(), name="test-question-detail"
+    ),
+    path("admin/test-list/", TestQuestionListView.as_view(), name="test-question-list"),
     path("test-questions/", TestQuestionCreateView.as_view(), name="test-question-create"),
     path("test-questions/<int:question_id>/", TestQuestionUpdateDeleteView.as_view(), name="test-question-detail"),
     path("tests/", TestQuestionListView.as_view(), name="test-question-list"),

--- a/apps/tests/views/admin_testquestion_views.py
+++ b/apps/tests/views/admin_testquestion_views.py
@@ -1,16 +1,19 @@
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.tests.models import TestQuestion
 from apps.tests.serializers.test_question_serializers import (
-    ErrorResponseSerializer,
+    DeleteResponseSerializer,
     TestListItemSerializer,
     TestQuestionCreateSerializer,
     TestQuestionUpdateSerializer,
 )
+from apps.tests.testquestion_permissions import IsAdminOrStaffByGroup
 
 
 # 문제 생성
@@ -83,7 +86,8 @@ class TestQuestionListView(APIView):
 
 # 문제 수정
 class TestQuestionUpdateDeleteView(APIView):
-    permission_classes = [AllowAny]
+    # permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated, IsAdminOrStaffByGroup]
 
     @extend_schema(
         tags=["[Admin] Test - Question (쪽지시험문제 생성/조회/수정/삭제)"],
@@ -106,14 +110,14 @@ class TestQuestionUpdateDeleteView(APIView):
     # 문제 삭제
     @extend_schema(
         tags=["[Admin] Test - Question (쪽지시험문제 생성/조회/수정/삭제)"],
-        description="Mock - 어드민이 등록한 쪽지시험 문제를 삭제합니다.",
+        description="어드민이 등록한 쪽지시험 문제를 삭제합니다.",
         responses={
             204: OpenApiResponse(description="삭제 성공"),
-            403: OpenApiResponse(response=ErrorResponseSerializer, description="이 작업을 수행할 권한이 없습니다."),
-            404: OpenApiResponse(response=ErrorResponseSerializer, description="문제를 찾을 수 없음"),
+            403: OpenApiResponse(response=DeleteResponseSerializer, description="이 작업을 수행할 권한이 없습니다."),
+            404: OpenApiResponse(response=DeleteResponseSerializer, description="문제를 찾을 수 없음"),
         },
     )
     def delete(self, request: Request, question_id: int) -> Response:
-        if question_id == 999:
-            return Response({"detail": "테스트 질문을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+        question = get_object_or_404(TestQuestion, id=question_id)
+        question.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/tests/views/admin_testquestion_views.py
+++ b/apps/tests/views/admin_testquestion_views.py
@@ -7,12 +7,14 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.tests.models import TestQuestion
+from apps.tests.permissions import IsAdminOrStaff
 from apps.tests.serializers.test_question_serializers import (
     TestListItemSerializer,
     TestQuestionCreateSerializer,
     TestQuestionUpdateSerializer,
 )
-from apps.tests.permissions import IsAdminOrStaff
+from apps.users.models import User
+
 
 # 문제 생성
 class TestQuestionCreateView(APIView):
@@ -85,7 +87,7 @@ class TestQuestionListView(APIView):
 # 문제 수정
 class TestQuestionUpdateDeleteView(APIView):
     # permission_classes = [AllowAny]
-    permission_classes = [IsAuthenticated,IsAdminOrStaff]
+    permission_classes = [IsAuthenticated, IsAdminOrStaff]
 
     @extend_schema(
         tags=["[Admin] Test - Question (쪽지시험문제 생성/조회/수정/삭제)"],
@@ -116,12 +118,12 @@ class TestQuestionUpdateDeleteView(APIView):
         },
     )
     def delete(self, request: Request, question_id: int) -> Response:
-        question = get_object_or_404(TestQuestion, id=question_id)
+        question = TestQuestion.objects.filter(id=question_id).first()
 
-        if not request.user.is_authenticated or not request.User.Role.ADMIN:
+        if not question:
             return Response(
-                {"detail": "이 작업을 수행할 권한이 없습니다."},
-                status=status.HTTP_403_FORBIDDEN,
+                {"detail": "문제를 찾을 수 없음"},
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         question.delete()


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 쪽지시험 문제 삭제 기능구현

## 📄 상세 내용
- [ ] admin_testquestion.py 수정
- [ ] 문제 삭제 url errorresponse에서 deleteresponese로 변경
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
