### PR TITLE
[Feature/test submissions submit gej] works: 사용자 쪽지시험 제출 기능 구현

### DIFF
--- a/apps/tests/permissions.py
+++ b/apps/tests/permissions.py
@@ -49,9 +49,7 @@ class IsStudent(BasePermission):
             return False
 
         # User.Role.choices 기반으로 STUDENT만 역할을 허용
-        allowed_roles = {User.Role.STUDENT}
-
-        if user.role in allowed_roles:
+        if user.role == User.Role.STUDENT:
             return True
 
         # 위 조건을 모두 통과하지 못하면 접근 거부

--- a/apps/tests/permissions.py
+++ b/apps/tests/permissions.py
@@ -26,3 +26,33 @@ class IsAdminOrStaff(BasePermission):
 
         # 위 조건을 모두 통과하지 못하면 접근 거부
         return False
+
+
+# 수강생(STUDENT) 역할을 가진 사용자만 허용
+class IsStudent(BasePermission):
+
+    message = "수강생 권한이 필요합니다."
+
+    def has_permission(self, request, view):
+
+        # 개발환경(DEBUG=True)에서는 무조건 허용
+
+        if settings.DEBUG:
+            # print("[INFO] DEBUG 모드: permission 우회 허용")
+            return True
+
+        # request.user = User.objects.get(id=1)
+        user = request.user
+
+        # 인증되지 않은 사용자면 거부
+        if not user or not user.is_authenticated:
+            return False
+
+        # User.Role.choices 기반으로 STUDENT만 역할을 허용
+        allowed_roles = {User.Role.STUDENT}
+
+        if user.role in allowed_roles:
+            return True
+
+        # 위 조건을 모두 통과하지 못하면 접근 거부
+        return False

--- a/apps/tests/serializers/test_deployment_serializers.py
+++ b/apps/tests/serializers/test_deployment_serializers.py
@@ -3,8 +3,7 @@ from typing import Any, Dict
 from rest_framework import serializers
 
 from apps.courses.models import Course, Generation
-from apps.tests.models import Test, TestDeployment
-from apps.tests.models import TestDeployment, TestQuestion
+from apps.tests.models import Test, TestDeployment, TestQuestion
 from apps.tests.serializers.test_question_serializers import (
     UserTestQuestionStartSerializer,
 )
@@ -119,8 +118,6 @@ class UserTestDeploymentSerializer(serializers.ModelSerializer[TestDeployment]):
         ordered_questions = [id_to_question[qid] for qid in question_ids if qid in id_to_question]
 
         return UserTestQuestionStartSerializer(ordered_questions, many=True).data
-
-
 
 
 # 🔹 공통 timestamp serializer (선택적)

--- a/apps/tests/serializers/test_deployment_serializers.py
+++ b/apps/tests/serializers/test_deployment_serializers.py
@@ -5,11 +5,12 @@ from rest_framework import serializers
 from apps.courses.models import Course, Generation
 from apps.tests.models import Test, TestDeployment
 from apps.tests.models import TestDeployment, TestQuestion
-from apps.tests.serializers.test_question_serializers import UserTestQuestionStartSerializer
+from apps.tests.serializers.test_question_serializers import (
+    UserTestQuestionStartSerializer,
+)
 from apps.tests.serializers.test_serializers import (
-
-    AdminTestSerializer, CommonTestSerializer,
-
+    AdminTestSerializer,
+    CommonTestSerializer,
 )
 
 
@@ -74,6 +75,33 @@ class AdminTestListDeploymentSerializer(serializers.ModelSerializer[TestDeployme
             "test",
             "generation",
         )
+
+
+# 사용자 쪽지 시험 응시: 요청, access_code 검증용
+class UserTestStartSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TestDeployment
+        fields = ("access_code",)
+        # extra_kwargs = {
+        #     "access_code": {"write_only": True},
+        # }
+        extra_kwargs = {
+            "access_code": {
+                "write_only": True,
+                "required": True,
+                "error_messages": {"required": "시험 코드를 입력해 주세요."},
+            }
+        }
+
+        # access_code 유효성 검사
+
+    def validate_access_code(self, value: str) -> str:
+        """
+        access_code 유효 여부 확인
+        """
+        if not TestDeployment.objects.filter(access_code=value).exists():
+            raise serializers.ValidationError("등록되지 않은 시험 코드입니다.")
+        return value
 
 
 # 사용자 쪽지 시험 응시: 응답, 시험 정보 응답용

--- a/apps/tests/serializers/test_deployment_serializers.py
+++ b/apps/tests/serializers/test_deployment_serializers.py
@@ -82,9 +82,6 @@ class UserTestStartSerializer(serializers.ModelSerializer):
     class Meta:
         model = TestDeployment
         fields = ("access_code",)
-        # extra_kwargs = {
-        #     "access_code": {"write_only": True},
-        # }
         extra_kwargs = {
             "access_code": {
                 "write_only": True,
@@ -93,12 +90,8 @@ class UserTestStartSerializer(serializers.ModelSerializer):
             }
         }
 
-        # access_code 유효성 검사
-
+    # access_code 유효성 검사
     def validate_access_code(self, value: str) -> str:
-        """
-        access_code 유효 여부 확인
-        """
         if not TestDeployment.objects.filter(access_code=value).exists():
             raise serializers.ValidationError("등록되지 않은 시험 코드입니다.")
         return value
@@ -122,7 +115,6 @@ class UserTestDeploymentSerializer(serializers.ModelSerializer[TestDeployment]):
         question_ids = [q["id"] for q in obj.questions_snapshot_json]
         questions = TestQuestion.objects.filter(id__in=question_ids)
 
-        # 질문 ID 순서 보존 (questions는 쿼리셋이라 순서가 안 맞을 수 있음)
         id_to_question = {q.id: q for q in questions}
         ordered_questions = [id_to_question[qid] for qid in question_ids if qid in id_to_question]
 

--- a/apps/tests/serializers/test_question_serializers.py
+++ b/apps/tests/serializers/test_question_serializers.py
@@ -83,11 +83,4 @@ class ErrorResponseSerializer(serializers.Serializer):  # type: ignore
 class UserTestQuestionStartSerializer(serializers.ModelSerializer[TestQuestion]):
     class Meta:
         model = TestQuestion
-        fields = (
-            'type',
-            'question',
-            'prompt',
-            'blank_count',
-            'options_json',
-            'point'
-        )
+        fields = ("type", "question", "prompt", "blank_count", "options_json", "point")

--- a/apps/tests/serializers/test_question_serializers.py
+++ b/apps/tests/serializers/test_question_serializers.py
@@ -72,3 +72,22 @@ class TestListItemSerializer(serializers.ModelSerializer):  # type: ignore
             "score",
             "correct_count",
         ]
+
+
+# 삭제 응답
+class ErrorResponseSerializer(serializers.Serializer):  # type: ignore
+    detail = serializers.CharField()
+
+
+# 사용자 쪽지 시험 응시: 응답, 시험 정보 응답용
+class UserTestQuestionStartSerializer(serializers.ModelSerializer[TestQuestion]):
+    class Meta:
+        model = TestQuestion
+        fields = (
+            'type',
+            'question',
+            'prompt',
+            'blank_count',
+            'options_json',
+            'point'
+        )

--- a/apps/tests/serializers/test_serializers.py
+++ b/apps/tests/serializers/test_serializers.py
@@ -144,17 +144,17 @@ class UserTestSerializer(serializers.ModelSerializer[Test]):
         fields = ("id", "subject", "title", "thumbnail_img_url")
 
 
-# 관리자 쪽지 시험 응시 전체 목록 조회
-class AdminListSubjectSerializer(serializers.ModelSerializer[Subject]):
+# 관리자 쪽지 시험 응시 전체 목록 조회, 사용자 응시
+class CommonSubjectSerializer(serializers.ModelSerializer[Subject]):
 
     class Meta:
         model = Subject
         fields = ("title",)
 
 
-# 관리자 쪽지 시험 응시 전체 목록 조회
-class AdminListSerializer(serializers.ModelSerializer[Test]):
-    subject = AdminListSubjectSerializer(read_only=True)
+# 관리자 쪽지 시험 응시 전체 목록 조회, 사용자 응시
+class CommonTestSerializer(serializers.ModelSerializer[Test]):
+    subject = CommonSubjectSerializer(read_only=True)
 
     class Meta:
         model = Test

--- a/apps/tests/serializers/test_submission_serializers.py
+++ b/apps/tests/serializers/test_submission_serializers.py
@@ -86,7 +86,6 @@ class UserTestSubmitSerializer(serializers.ModelSerializer[TestSubmission]):
             "cheating_count",
             "answers_json",
         )
-        read_only_fields = ("started_at",)
 
     def validate(self, data):
         deployment = self.context["deployment"]
@@ -125,7 +124,6 @@ class UserTestSubmitSerializer(serializers.ModelSerializer[TestSubmission]):
             self.auto_submit_message = "부정행위 3회 이상 적발되어 자동 제출 처리되었습니다."
 
         validated_data["deployment"] = deployment
-        validated_data["started_at"] = timezone.now()
 
         return super().create(validated_data)
 

--- a/apps/tests/urls.py
+++ b/apps/tests/urls.py
@@ -28,8 +28,8 @@ from .views.admin_testsubmission_views import (
 from .views.user_deploymentstatus_views import TestDeploymentStatusView
 from .views.user_testdeployments_views import UserCodeValidationView
 from .views.user_testsubmission_views import (
+    TestStartView,
     TestSubmissionResultView,
-    TestSubmissionStartView,
     TestSubmissionSubmitView,
 )
 
@@ -39,7 +39,7 @@ urlpatterns = [
     # 쪽지 시험 응시
     path(
         "test/submissions/<int:test_id>/start/",
-        TestSubmissionStartView.as_view(),
+        TestStartView.as_view(),
         name="submission_start",
     ),
     # 쪽지 시험 제출

--- a/apps/tests/views/user_testsubmission_views.py
+++ b/apps/tests/views/user_testsubmission_views.py
@@ -33,14 +33,16 @@ class TestSubmissionStartView(APIView):
         """
         이 API는 쪽지 시험 응시를 위한 test_id, access_code의 유효성을 판별합니다.
         """
-        serializer = self.request_serializer_class(data=request.data, context={'test_id':test_id})
+        serializer = self.request_serializer_class(data=request.data, context={"test_id": test_id})
         serializer.is_valid(raise_exception=True)
 
-        access_code = serializer.validated_data['access_code']
+        access_code = serializer.validated_data["access_code"]
         deployment = get_object_or_404(TestDeployment, access_code=access_code, test_id=test_id)
 
         response_serializer = self.response_serializer_class(instance=deployment)
-        return Response({"message": "Test started successfully.", "data": response_serializer.data}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": "Test started successfully.", "data": response_serializer.data}, status=status.HTTP_200_OK
+        )
 
 
 # 쪽지 시험 제출

--- a/apps/tests/views/user_testsubmission_views.py
+++ b/apps/tests/views/user_testsubmission_views.py
@@ -27,7 +27,7 @@ from apps.users.models import PermissionsStudent
     tags=["[User] Test - submission (쪽지시험 응시/제출/결과조회)"],
     request=UserTestStartSerializer,
 )
-class TestSubmissionStartView(APIView):
+class TestStartView(APIView):
     permission_classes = [IsAuthenticated]
     request_serializer_class = UserTestStartSerializer
     response_serializer_class = UserTestDeploymentSerializer

--- a/apps/tests/views/user_testsubmission_views.py
+++ b/apps/tests/views/user_testsubmission_views.py
@@ -24,8 +24,7 @@ from apps.tests.serializers.test_submission_serializers import (
     request=UserTestStartSerializer,
 )
 class TestSubmissionStartView(APIView):
-    permission_classes = [AllowAny]
-    # permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     request_serializer_class = UserTestStartSerializer
     response_serializer_class = UserTestDeploymentSerializer
 


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 사용자 쪽지시험 제출 기능 구현
  1. 시험 배포(TestDeployment)와 수강생(PermissionsStudent) 조회 시 404 처리 적용
  2. 제출 시 로그인한 수강생과 요청 데이터의 수강생 일치 여부 검증
  3. 답안 누락 및 시험 제출 시간 만료 시 에러 처리
  4. 부정행위 3회 이상 또는 제출 시간 만료 시 자동 제출 메시지 반환
  5. started_at 필드는 읽기 전용으로 설정

## 📄 상세 내용
- [x] tests/serializers/test_submission_serializers.py 수정
- [x] tests/views/user_testsubmission_veiws.py 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] Swagger 문서 작성 및 테스트 완료
- [x] 유효성 검사 및 예외처리 테스트 완료
