### PR TITLE
Feature/test listapi lsi (쪽지시험 목록조회 API)

### DIFF
--- a/apps/tests/pagination.py
+++ b/apps/tests/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class AdminTestListPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100

--- a/apps/tests/serializers/test_serializers.py
+++ b/apps/tests/serializers/test_serializers.py
@@ -114,11 +114,12 @@ class TestDetailSerializer(serializers.ModelSerializer):
         return TestQuestionDetailSerializer(obj.questions.all(), many=True).data
 
 
-# 쪽지시험 목록조회 Nested 구조 사용안함 응답 단순화
-class TestListSerializer(serializers.ModelSerializer[Test]):
+# 쪽지시험 목록조회
+class TestListSerializer(serializers.ModelSerializer):
     subject_name = serializers.CharField(source="subject.title")
     question_count = serializers.IntegerField()
     submission_count = serializers.IntegerField()
+    detail_url = serializers.SerializerMethodField()
 
     class Meta:
         model = Test
@@ -130,7 +131,11 @@ class TestListSerializer(serializers.ModelSerializer[Test]):
             "submission_count",
             "created_at",
             "updated_at",
+            "detail_url",
         )
+
+    def get_detail_url(self, obj):
+        return f"/api/v1/admin/tests/{obj.id}/"
 
 
 # 쪽지시험 생성


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 없음
- 작업 요약: 쪽지시험 목록조회 API 실제 구현 및 명세서 부분 수정

## 📄 상세 내용
- [] 기존 generation_id 필터 제거 후 course_id 필터로 수정하여 과정 단위 필터링 지원
- [] DRF PageNumberPagination 기반 페이지네이션 util 분리 및 적용
- [] 검색(시험명, 과목명 부분/완전일치) 및 정렬(최신순/가나다순) 기능 구현
- [] API 명세서에서 generation_id → course_id로 쿼리 파라미터 명세 변경 (기능적 스펙은 기존 유지)
- [] 피그마 UI 흐름과 일치하도록 기능 및 명세서 수정 사항 검토 완료

## 📸 스크린샷 (선택)
- 없음

## 📝 기타 참고 사항
- 명세서 내용은 course_id 필터 관련 부분만 수정되었으며, 다른 스펙/구조는 기존과 동일합니다.

## 🧪 PR Checklist
- [] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

