### PR TITLE
[Feature/test admin submissions list gej] works: 관리자 쪽지시험 응시 내역 전체 조회 기능 구현

### DIFF
--- a/apps/tests/core/utils/filters.py
+++ b/apps/tests/core/utils/filters.py
@@ -1,0 +1,58 @@
+def filter_test_submissions(queryset, filters):
+    subject = filters.get("subject_title")
+    course = filters.get("course_title")
+    generation = filters.get("generation_number")
+
+    # 필요하면 strip()도 추가
+    subject = subject.strip() if subject else None
+    course = course.strip() if course else None
+    generation = int(generation) if generation else None
+
+    print("subject_title 값:", subject)
+    print("course_title 값:", course)
+    print("generation_number 값:", generation)
+
+
+    if subject:
+        queryset = queryset.filter(deployment__test__subject__title__icontains=subject)
+        print(queryset.count())
+        print(list(queryset))
+    if course:
+        queryset = queryset.filter(deployment__generation__course__name__icontains=course)
+    if generation:
+        queryset = queryset.filter(deployment__generation__number=generation)
+
+    return queryset
+
+    # # case 1: 과목만 있는 경우
+    # if subject and not course and not generation:
+    #     return queryset.filter(deployment__test__subject__title__icontains=subject)
+    #
+    # # case 2: 과정 + 기수만 있는 경우
+    # if not subject and course and generation:
+    #     return queryset.filter(
+    #         deployment__generation__course__name__icontains=course,
+    #         deployment__generation__number=generation
+    #     )
+    #
+    # # case 3: 과목 + 과정 + 기수 모두 있는 경우
+    # if subject and course and generation:
+    #     return queryset.filter(
+    #         deployment__test__subject__title__icontains=subject,
+    #         deployment__generation__course__name__icontains=course,
+    #         deployment__generation__number=generation
+    #     )
+    #
+    # # case 4: 아무 조건도 없으면 전체 조회
+    # return queryset
+
+# 과목만 선택하는 경우 해당 과목에 응시한 모든 응시내역을 조회
+# 과정 - 기수를 모두 선택하는 경우 응시내역 중 해당 과정 - 기수가 응시한 모든 응시내역을 조회
+# 둘다 선택하는 경우 응시내역 중 해당 과목에 대해서 해당 과정 - 기수가 응시한 모든 응시내역을 조회
+
+
+    # case 1: 과목만 있는 경우
+
+
+
+

--- a/apps/tests/core/utils/filters.py
+++ b/apps/tests/core/utils/filters.py
@@ -3,15 +3,9 @@ def filter_test_submissions(queryset, filters):
     course = filters.get("course_title")
     generation = filters.get("generation_number")
 
-    # 필요하면 strip()도 추가
     subject = subject.strip() if subject else None
     course = course.strip() if course else None
     generation = int(generation) if generation else None
-
-    print("subject_title 값:", subject)
-    print("course_title 값:", course)
-    print("generation_number 값:", generation)
-
 
     if subject:
         queryset = queryset.filter(deployment__test__subject__title__icontains=subject)
@@ -23,36 +17,3 @@ def filter_test_submissions(queryset, filters):
         queryset = queryset.filter(deployment__generation__number=generation)
 
     return queryset
-
-    # # case 1: 과목만 있는 경우
-    # if subject and not course and not generation:
-    #     return queryset.filter(deployment__test__subject__title__icontains=subject)
-    #
-    # # case 2: 과정 + 기수만 있는 경우
-    # if not subject and course and generation:
-    #     return queryset.filter(
-    #         deployment__generation__course__name__icontains=course,
-    #         deployment__generation__number=generation
-    #     )
-    #
-    # # case 3: 과목 + 과정 + 기수 모두 있는 경우
-    # if subject and course and generation:
-    #     return queryset.filter(
-    #         deployment__test__subject__title__icontains=subject,
-    #         deployment__generation__course__name__icontains=course,
-    #         deployment__generation__number=generation
-    #     )
-    #
-    # # case 4: 아무 조건도 없으면 전체 조회
-    # return queryset
-
-# 과목만 선택하는 경우 해당 과목에 응시한 모든 응시내역을 조회
-# 과정 - 기수를 모두 선택하는 경우 응시내역 중 해당 과정 - 기수가 응시한 모든 응시내역을 조회
-# 둘다 선택하는 경우 응시내역 중 해당 과목에 대해서 해당 과정 - 기수가 응시한 모든 응시내역을 조회
-
-
-    # case 1: 과목만 있는 경우
-
-
-
-

--- a/apps/tests/core/utils/filters.py
+++ b/apps/tests/core/utils/filters.py
@@ -9,8 +9,6 @@ def filter_test_submissions(queryset, filters):
 
     if subject:
         queryset = queryset.filter(deployment__test__subject__title__icontains=subject)
-        print(queryset.count())
-        print(list(queryset))
     if course:
         queryset = queryset.filter(deployment__generation__course__name__icontains=course)
     if generation:

--- a/apps/tests/core/utils/pagination.py
+++ b/apps/tests/core/utils/pagination.py
@@ -1,0 +1,29 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class PaginationList(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+# def paginate_list(data: list, page: int, page_size: int) -> dict:
+#     total_count = len(data)
+#     total_pages = (total_count + page_size - 1) // page_size
+#     start = (page - 1) * page_size
+#     end = start + page_size
+#     paged_data = data[start:end]
+#     return {
+#         "paged_data": paged_data,
+#         "pagination": {
+#             "page": page,
+#             "page_size": page_size,
+#             "total_count": total_count,
+#             "total_pages": total_pages,
+#         },
+#     }
+
+# result = paginate_list(submissions, filters.get("page", 1), filters.get("page_size", 10))
+# paged_submissions = result["paged_data"]
+# pagination_info = result["pagination"]
+#
+# serializer = self.serializer_class(paged_submissions, many=True)

--- a/apps/tests/core/utils/pagination.py
+++ b/apps/tests/core/utils/pagination.py
@@ -5,25 +5,3 @@ class PaginationList(PageNumberPagination):
     page_size = 10
     page_size_query_param = "page_size"
     max_page_size = 100
-
-# def paginate_list(data: list, page: int, page_size: int) -> dict:
-#     total_count = len(data)
-#     total_pages = (total_count + page_size - 1) // page_size
-#     start = (page - 1) * page_size
-#     end = start + page_size
-#     paged_data = data[start:end]
-#     return {
-#         "paged_data": paged_data,
-#         "pagination": {
-#             "page": page,
-#             "page_size": page_size,
-#             "total_count": total_count,
-#             "total_pages": total_pages,
-#         },
-#     }
-
-# result = paginate_list(submissions, filters.get("page", 1), filters.get("page_size", 10))
-# paged_submissions = result["paged_data"]
-# pagination_info = result["pagination"]
-#
-# serializer = self.serializer_class(paged_submissions, many=True)

--- a/apps/tests/core/utils/pagination.py
+++ b/apps/tests/core/utils/pagination.py
@@ -1,7 +1,0 @@
-from rest_framework.pagination import PageNumberPagination
-
-
-class PaginationList(PageNumberPagination):
-    page_size = 10
-    page_size_query_param = "page_size"
-    max_page_size = 100

--- a/apps/tests/core/utils/sorting.py
+++ b/apps/tests/core/utils/sorting.py
@@ -1,9 +1,11 @@
 from apps.tests.models import TestSubmission
-from apps.tests.serializers.test_submission_serializers import AdminTestListSerializer
+from apps.tests.serializers.test_submission_serializers import (
+    AdminTestSubmissionListSerializer,
+)
 
 
 def annotate_total_score(submissions: list[TestSubmission]) -> list[TestSubmission]:
-    serializer = AdminTestListSerializer()
+    serializer = AdminTestSubmissionListSerializer()
     for submission in submissions:
         submission.total_score = serializer.get_total_score(submission)  # type: ignore[attr-defined]
     return submissions

--- a/apps/tests/core/utils/sorting.py
+++ b/apps/tests/core/utils/sorting.py
@@ -1,7 +1,7 @@
 from apps.tests.models import TestSubmission
 from apps.tests.serializers.test_submission_serializers import AdminTestListSerializer
 
-# total_score 계산해서 각 객체에 속성으로 붙이기
+
 def annotate_total_score(submissions: list[TestSubmission]) -> list[TestSubmission]:
     serializer = AdminTestListSerializer()
     for submission in submissions:
@@ -10,20 +10,12 @@ def annotate_total_score(submissions: list[TestSubmission]) -> list[TestSubmissi
 
 
 def sort_by_total_score(data: list[TestSubmission], ordering: str) -> list[TestSubmission]:
-    # data = list(data)
     if ordering == "total_score_desc":
         data.sort(key=lambda x: x.total_score, reverse=True)  # type: ignore[attr-defined]
     elif ordering == "total_score_asc":
         data.sort(key=lambda x: x.total_score)  # type: ignore[attr-defined]
     else:
-        # 기본 정렬은 created_at 기준 (내림차순)
+        # 기본 정렬: 내림차순
         data.sort(key=lambda x: x.created_at, reverse=True)
 
     return data
-
-# def sort_list(queryset, ordering: str):
-#     if ordering == "score_desc":
-#         return queryset.order_by("-score")
-#     elif ordering == "score_asc":
-#         return queryset.order_by("score")
-#     return queryset.order_by("-created_at")

--- a/apps/tests/core/utils/sorting.py
+++ b/apps/tests/core/utils/sorting.py
@@ -1,0 +1,29 @@
+from apps.tests.models import TestSubmission
+from apps.tests.serializers.test_submission_serializers import AdminTestListSerializer
+
+# total_score 계산해서 각 객체에 속성으로 붙이기
+def annotate_total_score(submissions: list[TestSubmission]) -> list[TestSubmission]:
+    serializer = AdminTestListSerializer()
+    for submission in submissions:
+        submission.total_score = serializer.get_total_score(submission)  # type: ignore[attr-defined]
+    return submissions
+
+
+def sort_by_total_score(data: list[TestSubmission], ordering: str) -> list[TestSubmission]:
+    # data = list(data)
+    if ordering == "total_score_desc":
+        data.sort(key=lambda x: x.total_score, reverse=True)  # type: ignore[attr-defined]
+    elif ordering == "total_score_asc":
+        data.sort(key=lambda x: x.total_score)  # type: ignore[attr-defined]
+    else:
+        # 기본 정렬은 created_at 기준 (내림차순)
+        data.sort(key=lambda x: x.created_at, reverse=True)
+
+    return data
+
+# def sort_list(queryset, ordering: str):
+#     if ordering == "score_desc":
+#         return queryset.order_by("-score")
+#     elif ordering == "score_asc":
+#         return queryset.order_by("score")
+#     return queryset.order_by("-created_at")

--- a/apps/tests/serializers/test_submission_serializers.py
+++ b/apps/tests/serializers/test_submission_serializers.py
@@ -1,7 +1,7 @@
 from django.utils import timezone
 from rest_framework import request, serializers
 
-from apps.tests.models import TestDeployment, TestSubmission
+from apps.tests.models import TestDeployment, TestQuestion, TestSubmission
 from apps.tests.serializers.test_deployment_serializers import (
     AdminTestDeploymentSerializer,
     AdminTestListDeploymentSerializer,
@@ -52,8 +52,62 @@ class AdminTestListSerializer(serializers.ModelSerializer[TestSubmission]):
         model = TestSubmission
         fields = ("id", "deployment", "student", "cheating_count", "total_score", "started_at", "created_at")
 
+    @staticmethod
+    def is_correct(submitted_answer, correct_answer):
+        # 정답과 제출 답안이 같으면 True 반환
+        return submitted_answer == correct_answer
+
     def get_total_score(self, obj):
-        return 30  # 그냥 고정 점수 예시
+        total = 0
+        answers = obj.answers_json
+
+        questions_ids = []
+
+        # 모든 문제 ID 추출
+        for qid in answers.keys():
+            try:
+                questions_ids.append(int(qid))
+            except ValueError:
+                continue
+
+        # 한 번에 문제들 조회
+        questions = TestQuestion.objects.filter(id__in=questions_ids)
+
+        # ID별로 쉽게 접근하도록 딕셔너리 생성
+        question_dice = {question.id: question for question in questions}
+
+        # 반복문으로 캐시된 문제를 객체로 처리
+        for question_id_str, submitted_answer in answers.items():
+            try:
+                question_id = int(question_id_str)
+            except ValueError:
+                continue
+            question = question_dice.get(question_id)  # 딕셔너리에서 꺼내기
+            if not question:
+                continue  # 문제 없으면 패스
+
+            if self.is_correct(submitted_answer, question.answer):
+                total += question.point
+
+        return total
+
+
+# 관리자 쪽지 시험 응시 전체 목록 조회 검색 필터
+class TestSubmissionFilterSerializer(serializers.Serializer):
+    subject_title = serializers.CharField(required=False, allow_blank=True)
+    course_title = serializers.CharField(required=False, allow_blank=True)
+    generation_number = serializers.IntegerField(required=False)
+    ordering = serializers.ChoiceField(
+        choices=[
+            ("latest", "최신순"),
+            ("total_score_desc", "점수가 높은 순"),
+            ("total_score_asc", "점수가 낮은 순"),
+        ],
+        default="latest",
+        required=False,
+    )
+    page = serializers.IntegerField(min_value=1, default=1, required=False)
+    page_size = serializers.IntegerField(min_value=1, max_value=100, default=10, required=False)
 
 
 # 관리자 쪽지 시험 응시 상세 조회

--- a/apps/tests/views/admin_testsubmission_views.py
+++ b/apps/tests/views/admin_testsubmission_views.py
@@ -1,5 +1,5 @@
 from django.contrib.admin.templatetags.admin_list import pagination
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -25,105 +25,79 @@ from apps.users.models.permissions import PermissionsStudent
 @extend_schema(
     tags=["[Admin] Test - submission (쪽지시험 응시 목록/상세/삭제)"],
     parameters=[
-        OpenApiParameter(name='subject_title', type=str, location=OpenApiParameter.QUERY, description='과목명으로 모든 응시내역 조회', required=False),
-        OpenApiParameter(name='course_title', type=str, location=OpenApiParameter.QUERY, description='과정명과 기수 고유 ID로 기수가 응시한 모든 응시내역 조회', required=False),
-        OpenApiParameter(name='generation_number', type=int, location=OpenApiParameter.QUERY, description='과목명, 과정명, 기수 고유 ID로 기수가 응시한 모든 응시내역 조회', required=False),
         OpenApiParameter(
-            name='ordering',
+            name="subject_title",
+            type=str,
+            location=OpenApiParameter.QUERY,
+            description="과목명으로 모든 응시내역 조회",
+            required=False,
+        ),
+        OpenApiParameter(
+            name="course_title",
+            type=str,
+            location=OpenApiParameter.QUERY,
+            description="과정명과 기수 고유 ID로 기수가 응시한 모든 응시내역 조회",
+            required=False,
+        ),
+        OpenApiParameter(
+            name="generation_number",
+            type=int,
+            location=OpenApiParameter.QUERY,
+            description="과목명, 과정명, 기수 고유 ID로 기수가 응시한 모든 응시내역 조회",
+            required=False,
+        ),
+        OpenApiParameter(
+            name="ordering",
             type=str,
             location=OpenApiParameter.QUERY,
             required=False,
-            enum=['latest', 'total_score_desc', 'total_score_asc'],
-            description='정렬 기준: 최신순(latest), 총점 높은 순(total_score_desc), 총점 낮은 순(total_score_asc)',
+            enum=["latest", "total_score_desc", "total_score_asc"],
+            description="정렬 기준: 최신순(latest), 총점 높은 순(total_score_desc), 총점 낮은 순(total_score_asc)",
         ),
-        OpenApiParameter(name='page', type=int, location=OpenApiParameter.QUERY, required=False),
-        OpenApiParameter(name='page_size', type=int, location=OpenApiParameter.QUERY, required=False),
-    ]
+        OpenApiParameter(
+            name="page",
+            type=int,
+            location=OpenApiParameter.QUERY,
+            description="페이지 번호 (기본값: 1)",
+            required=False,
+        ),
+    ],
 )
-
 class AdminTestSubmissionsView(APIView):
     permission_classes = [AllowAny]
     # permission_classes = [IsAuthenticated, IsAdminOrStaff]
     serializer_class = AdminTestListSerializer
-    pagination_class = pagination
 
     def get(self, request: Request) -> Response:
-        print("AdminTestSubmissionsView GET 메서드 호출됨")
-        print("request.query_params:", request.query_params)
-
-        submission = TestSubmission.objects.get(id=20)
-        print("number:", submission.deployment.generation.number)
-
         filter_serializer = TestSubmissionFilterSerializer(data=request.query_params)
-        print("request.query_params:", dict(request.query_params))
-
-        if not filter_serializer.is_valid():
-            print("필터 유효성 검사 실패:", filter_serializer.errors)
-        else:
-            print("필터 유효성 검사 성공", filter_serializer.validated_data)
-        #filter_serializer.is_valid(raise_exception=True)
-
+        filter_serializer.is_valid(raise_exception=True)
         filters = filter_serializer.validated_data
-        print("filters:", filters)
 
-
-        #1. QuerySet 상태에서 필터 적용
-        test_submission_filtered_qs = filter_test_submissions(
-            TestSubmission.objects.select_related(
-                "student__user", "deployment__test", "deployment__generation__course"
-            ),
-            filters,
+        queryset = TestSubmission.objects.select_related(
+            "student__user", "deployment__test", "deployment__generation__course"
         )
+        filtered_qs = filter_test_submissions(queryset, filters)
 
-        print("filters:", filters)
-        for submission in test_submission_filtered_qs:
-            print(submission.deployment.generation.id, submission.deployment.generation.number)
-        print("QuerySet 상태에서 필터 적용:", test_submission_filtered_qs)
+        if any(filters.values()) and not filtered_qs.exists():
+            return Response(
+                {"detail": "검색어로 조회된 결과가 없습니다."},
+                status=404,
+            )
 
-        generations = Generation.objects.all()
-        for gen in generations:
-            print(f"id: {gen.id}, number: {gen.number}, course_id: {gen.course_id}")
-
-        if any(filters.values()) and not test_submission_filtered_qs.exists():
-            return Response({"detail": "검색어로 조회된 결과가 없습니다."}, status=404,)
-
-        #QuerySet → 리스트 변환
-        submissions = list(test_submission_filtered_qs)
-        # total_score 계산해서 인스턴스에 붙이기
+        submissions = list(filtered_qs)
         submissions_with_scores = annotate_total_score(submissions)
 
         ordering = filters.get("ordering", "latest")
         sorted_submissions = sort_by_total_score(submissions_with_scores, ordering)
 
+        paginator = PageNumberPagination()
+        page = paginator.paginate_queryset(sorted_submissions, request)  # type: ignore
 
-        paginator = PaginationList()
-        # paginate_queryset() 같은 DRF 함수들은 QuerySet을 기대
-        # 총점(total_score)이 DB 필드가 아니라 파이썬에서 계산된 값이라서
-        # QuerySet 상태에서 정렬이 안 되고, 어쩔 수 없이 파이썬 리스트로 변환해서 정렬
-        page = paginator.paginate_queryset(sorted_submissions, request)  # type: ignore #
         serializer = self.serializer_class(page, many=True)
 
         return Response(
             {"message": "쪽지시험 응시내역 목록 조회 완료", "data": serializer.data}, status=status.HTTP_200_OK
         )
-
-        # test_submission = TestSubmission.objects.select_related(
-        #     "student__user", "deployment__test", "deployment__generation__course"
-        # ).all()
-        #
-        # filtered = filter_test_submissions(test_submission, filters)
-        # sorted_qs = sort_list(filtered, filters.get("ordering", "latest"))
-        #
-        # paginator = PaginationList()
-        # page = paginator.paginate_queryset(sorted_qs, request)
-        # serializer = self.serializer_class(page, many=True)
-        #
-        # return Response(
-        #     {"message": "쪽지시험 응시내역 목록 조회 완료", "data": serializer.data},
-        #     status=status.HTTP_200_OK,
-        # )
-
-
 
 
 # 쪽지 시험 응시 내역 상세 조회

--- a/apps/tests/views/admin_testsubmission_views.py
+++ b/apps/tests/views/admin_testsubmission_views.py
@@ -1,4 +1,3 @@
-from django.contrib.admin.templatetags.admin_list import pagination
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
@@ -9,9 +8,9 @@ from rest_framework.views import APIView
 
 from apps.courses.models import Course, Generation, Subject, User
 from apps.tests.core.utils.filters import filter_test_submissions
-from apps.tests.core.utils.pagination import PaginationList
 from apps.tests.core.utils.sorting import annotate_total_score, sort_by_total_score
 from apps.tests.models import Test, TestDeployment, TestSubmission
+from apps.tests.pagination import AdminTestListPagination
 from apps.tests.permissions import IsAdminOrStaff
 from apps.tests.serializers.test_submission_serializers import (
     AdminTestDetailSerializer,
@@ -64,8 +63,7 @@ from apps.users.models.permissions import PermissionsStudent
     ],
 )
 class AdminTestSubmissionsView(APIView):
-    permission_classes = [AllowAny]
-    # permission_classes = [IsAuthenticated, IsAdminOrStaff]
+    permission_classes = [IsAuthenticated, IsAdminOrStaff]
     serializer_class = AdminTestListSerializer
 
     def get(self, request: Request) -> Response:
@@ -90,7 +88,7 @@ class AdminTestSubmissionsView(APIView):
         ordering = filters.get("ordering", "latest")
         sorted_submissions = sort_by_total_score(submissions_with_scores, ordering)
 
-        paginator = PageNumberPagination()
+        paginator = AdminTestListPagination()
         page = paginator.paginate_queryset(sorted_submissions, request)  # type: ignore
 
         serializer = self.serializer_class(page, many=True)
@@ -101,7 +99,7 @@ class AdminTestSubmissionsView(APIView):
 
 
 # 쪽지 시험 응시 내역 상세 조회
-@extend_schema(tags=["[Admin] Test - submission (쪽지시험 응시 목록/상세/삭제)"])
+@extend_schema(tags=["[Admin/Mock] Test - submission (쪽지시험 응시 목록/상세/삭제)"])
 class AdminTestSubmissionDetailView(APIView):
     permission_classes = [AllowAny]
     serializer_class = AdminTestDetailSerializer

--- a/apps/tests/views/admin_testsubmission_views.py
+++ b/apps/tests/views/admin_testsubmission_views.py
@@ -14,7 +14,7 @@ from apps.tests.pagination import AdminTestListPagination
 from apps.tests.permissions import IsAdminOrStaff
 from apps.tests.serializers.test_submission_serializers import (
     AdminTestDetailSerializer,
-    AdminTestListSerializer,
+    AdminTestSubmissionListSerializer,
     TestSubmissionFilterSerializer,
 )
 from apps.users.models.permissions import PermissionsStudent
@@ -64,7 +64,7 @@ from apps.users.models.permissions import PermissionsStudent
 )
 class AdminTestSubmissionsView(APIView):
     permission_classes = [IsAuthenticated, IsAdminOrStaff]
-    serializer_class = AdminTestListSerializer
+    serializer_class = AdminTestSubmissionListSerializer
 
     def get(self, request: Request) -> Response:
         filter_serializer = TestSubmissionFilterSerializer(data=request.query_params)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #
- 작업 요약: 관리자용 쪽지시험 응시 내역 전체 조회 API 개발
  1. select_related로 TestSubmission과 연관된 student, deployment, test, generation, course를 효율 조회
  2. filter_test_submissions 함수로 subject_title, course_title, generation_number 필터링 분리 적용
  3. 조회 결과를 리스트로 변환 후 annotate_total_score 함수로 total_score 실시간 계산 및 인스턴스에 추가
  4. AdminTestSubmissionListSerializer에 SerializerMethodField로 total_score 정의, 점수 계산 로직 캡슐화
  5. is_correct() 메서드 도입으로 답안 검증 로직 분리해 가독성 및 유지보수성 향상
  6. 커스텀 페이징 클래스(AdminTestListPagination)로 리스트 페이징 처리 커스터마이징
  7. 필터링, 정렬, 페이징, 직렬화 일관된 흐름으로 관리자 페이지 요구사항 충족

## 📄 상세 내용
- [x] tests/views/admin_testsubmission_views.py 수정
- [x] tests/serializers/test_submission_serializers.py 수정
- [x] tests/core/utils/filters.py, sorting.py 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] Swagger 문서 작성 및 테스트 완료
- [x] 유효성 검사 테스트 완료
