### PR TITLE
[Feature/test admin submissions detail gej] works: 관리자 쪽지시험 응시 내역 상세 조회 기능 구현 

### DIFF
--- a/apps/tests/core/utils/grading.py
+++ b/apps/tests/core/utils/grading.py
@@ -1,0 +1,50 @@
+from rest_framework.exceptions import ValidationError
+
+from apps.tests.models import TestQuestion
+
+
+def validate_answers_json_format(answers_json):
+    if not isinstance(answers_json, dict):
+        raise ValidationError("answers_json은 딕셔너리 형식이어야 합니다.")
+
+
+def is_correct(submitted_answer, correct_answer):
+    return submitted_answer == correct_answer
+
+
+# 총 점수
+def calculate_total_score(answers_json):
+    total = 0
+    question_ids = [int(k) for k in answers_json.keys() if k.isdigit()]
+    questions = TestQuestion.objects.filter(id__in=question_ids)
+    question_map = {q.id: q for q in questions}
+
+    for qid_str, submitted_answer in answers_json.items():
+        qid = int(qid_str)
+        question = question_map.get(qid)
+        if not question:
+            continue
+
+        if is_correct(submitted_answer, question.answer):
+            total += question.point
+
+    return total
+
+
+# 맞은 문제 수
+def calculate_correct_count(answers_json):
+    count = 0
+    question_ids = [int(k) for k in answers_json.keys() if k.isdigit()]
+    questions = TestQuestion.objects.filter(id__in=question_ids)
+    question_map = {q.id: q for q in questions}
+
+    for qid_str, submitted_answer in answers_json.items():
+        qid = int(qid_str)
+        question = question_map.get(qid)
+        if not question:
+            continue
+
+        if is_correct(submitted_answer, question.answer):
+            count += 1
+
+    return count

--- a/apps/tests/serializers/test_deployment_serializers.py
+++ b/apps/tests/serializers/test_deployment_serializers.py
@@ -24,8 +24,9 @@ from apps.tests.serializers.test_question_serializers import (
     UserTestQuestionStartSerializer,
 )
 from apps.tests.serializers.test_serializers import (
-    AdminTestSerializer,
-    CommonTestSerializer,
+    AdminTestDetailSerializer,
+    AdminTestListSerializer,
+    UserTestSerializer,
 )
 
 
@@ -36,23 +37,24 @@ class CourseSerializer(serializers.ModelSerializer[Course]):
         fields = ("id", "name")
 
 
+# 삭제 공유
 # 공통 User&Admin
-class GenerationSerializer(serializers.ModelSerializer[Generation]):
-    course = CourseSerializer(read_only=True)
+# class GenerationSerializer(serializers.ModelSerializer[Generation]):
+#     course = CourseSerializer(read_only=True)
+#
+#     class Meta:
+#         model = Generation
+#         fields = ("id", "course", "number")
 
-    class Meta:
-        model = Generation
-        fields = ("id", "course", "number")
 
-
-# 관리자 쪽지 시험 응시 전체 목록 조회
+# 관리자 쪽지 시험 응시 전체 목록 조회, 상세 조회
 class AdminListCourseSerializer(serializers.ModelSerializer[Course]):
     class Meta:
         model = Course
         fields = ("name",)
 
 
-# 관리자 쪽지 시험 응시 전체 목록 조회
+# 관리자 쪽지 시험 응시 전체 목록 조회, 상세 조회
 class AdminListGenerationSerializer(serializers.ModelSerializer[Generation]):
     course = AdminListCourseSerializer(read_only=True)
 
@@ -61,15 +63,14 @@ class AdminListGenerationSerializer(serializers.ModelSerializer[Generation]):
         fields = ("course", "number")
 
 
-# 공통 AdminTestDeploymentSerializer
+# 관리자 쪽지 시험 응시 상세 조회
 class AdminTestDeploymentSerializer(serializers.ModelSerializer[TestDeployment]):
-    test = AdminTestSerializer(read_only=True)
-    generation = GenerationSerializer(read_only=True)
+    test = AdminTestDetailSerializer(read_only=True)
+    generation = AdminListGenerationSerializer(read_only=True)
 
     class Meta:
         model = TestDeployment
         fields = (
-            "id",
             "test",
             "generation",
             "duration_time",
@@ -81,7 +82,7 @@ class AdminTestDeploymentSerializer(serializers.ModelSerializer[TestDeployment])
 
 # 관리자 쪽지 시험 응시 전체 목록 조회
 class AdminTestListDeploymentSerializer(serializers.ModelSerializer[TestDeployment]):
-    test = CommonTestSerializer(read_only=True)
+    test = AdminTestListSerializer(read_only=True)
     generation = AdminListGenerationSerializer(read_only=True)
 
     class Meta:
@@ -108,7 +109,7 @@ class UserTestStartSerializer(serializers.Serializer):
 
 # 사용자 쪽지 시험 응시: 응답, 시험 정보 응답용
 class UserTestDeploymentSerializer(serializers.ModelSerializer[TestDeployment]):
-    test = CommonTestSerializer(read_only=True)
+    test = UserTestSerializer(read_only=True)
     questions_snapshot_json = serializers.SerializerMethodField()
 
     class Meta:

--- a/apps/tests/serializers/test_serializers.py
+++ b/apps/tests/serializers/test_serializers.py
@@ -202,25 +202,8 @@ class TestCreateSerializer(serializers.ModelSerializer[Test]):
         return test
 
 
-# 공통 AdminTestSerializer
-class AdminTestSerializer(serializers.ModelSerializer[Test]):
-    subject = TestSubjectSerializer(read_only=True)
-
-    class Meta:
-        model = Test
-        fields = ("id", "subject", "title", "created_at", "updated_at")
-
-
-# 공통 UserTestSerializer
-class UserTestSerializer(serializers.ModelSerializer[Test]):
-    subject = TestSubjectSerializer(read_only=True)
-
-    class Meta:
-        model = Test
-        fields = ("id", "subject", "title", "thumbnail_img_url")
-
-
-# 관리자 쪽지 시험 응시 전체 목록 조회, 사용자 응시
+# 상인님 subject 임포트 중이었는데, id가 필요없어서 새로 생성
+# 관리자 쪽지 시험 응시 전체 목록 조회, 상세 조회, 사용자 응시
 class CommonSubjectSerializer(serializers.ModelSerializer[Subject]):
 
     class Meta:
@@ -228,8 +211,26 @@ class CommonSubjectSerializer(serializers.ModelSerializer[Subject]):
         fields = ("title",)
 
 
-# 관리자 쪽지 시험 응시 전체 목록 조회, 사용자 응시
-class CommonTestSerializer(serializers.ModelSerializer[Test]):
+# 관리자 쪽지 시험 응시 상세 조회
+class AdminTestDetailSerializer(serializers.ModelSerializer[Test]):
+    subject = CommonSubjectSerializer(read_only=True)
+
+    class Meta:
+        model = Test
+        fields = ("subject", "title", "created_at", "updated_at")
+
+
+# 사용자 쪽지 시험 응시
+class UserTestSerializer(serializers.ModelSerializer[Test]):
+    subject = CommonSubjectSerializer(read_only=True)
+
+    class Meta:
+        model = Test
+        fields = ("subject", "title", "thumbnail_img_url")
+
+
+# 관리자 쪽지 시험 응시 전체 목록 조회
+class AdminTestListSerializer(serializers.ModelSerializer[Test]):
     subject = CommonSubjectSerializer(read_only=True)
 
     class Meta:

--- a/apps/tests/views/admin_testsubmission_views.py
+++ b/apps/tests/views/admin_testsubmission_views.py
@@ -13,8 +13,8 @@ from apps.tests.pagination import AdminTestListPagination
 from apps.tests.permissions import IsAdminOrStaff
 from apps.tests.serializers.test_submission_serializers import (
     AdminTestDetailSerializer,
-    TestSubmissionFilterSerializer,
     AdminTestSubmissionListSerializer,
+    TestSubmissionFilterSerializer,
 )
 
 
@@ -103,9 +103,12 @@ class AdminTestSubmissionDetailView(APIView):
     serializer_class = AdminTestDetailSerializer
 
     def get(self, request: Request, submission_id: int) -> Response:
-        test_submission = get_object_or_404(
-            TestSubmission.objects.select_related("student", "deployment__test"), pk=submission_id
-        )
+        try:
+            test_submission = TestSubmission.objects.select_related("student", "deployment__test").get(pk=submission_id)
+        except TestSubmission.DoesNotExist:
+            return Response(
+                {"detail": f"{submission_id}에 해당하는 객체가 존재하지 않습니다."}, status=status.HTTP_404_NOT_FOUND
+            )
 
         serializer = self.serializer_class(instance=test_submission)
 

--- a/apps/tests/views/admin_testsubmission_views.py
+++ b/apps/tests/views/admin_testsubmission_views.py
@@ -1,23 +1,21 @@
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.courses.models import Course, Generation, Subject, User
 from apps.tests.core.utils.filters import filter_test_submissions
 from apps.tests.core.utils.sorting import annotate_total_score, sort_by_total_score
-from apps.tests.models import Test, TestDeployment, TestSubmission
+from apps.tests.models import TestSubmission
 from apps.tests.pagination import AdminTestListPagination
 from apps.tests.permissions import IsAdminOrStaff
 from apps.tests.serializers.test_submission_serializers import (
     AdminTestDetailSerializer,
-    AdminTestSubmissionListSerializer,
     TestSubmissionFilterSerializer,
+    AdminTestSubmissionListSerializer,
 )
-from apps.users.models.permissions import PermissionsStudent
 
 
 # 쪽지 시험 응시 내역 전체 목록 조회
@@ -99,7 +97,7 @@ class AdminTestSubmissionsView(APIView):
 
 
 # 쪽지 시험 응시 내역 상세 조회
-@extend_schema(tags=["[Admin/Mock] Test - submission (쪽지시험 응시 목록/상세/삭제)"])
+@extend_schema(tags=["[Admin] Test - submission (쪽지시험 응시 목록/상세/삭제)"])
 class AdminTestSubmissionDetailView(APIView):
     permission_classes = [IsAuthenticated, IsAdminOrStaff]
     serializer_class = AdminTestDetailSerializer

--- a/apps/tests/views/admin_testsubmission_views.py
+++ b/apps/tests/views/admin_testsubmission_views.py
@@ -101,115 +101,16 @@ class AdminTestSubmissionsView(APIView):
 # 쪽지 시험 응시 내역 상세 조회
 @extend_schema(tags=["[Admin/Mock] Test - submission (쪽지시험 응시 목록/상세/삭제)"])
 class AdminTestSubmissionDetailView(APIView):
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated, IsAdminOrStaff]
     serializer_class = AdminTestDetailSerializer
 
     def get(self, request: Request, submission_id: int) -> Response:
-        mock_data = TestSubmission(
-            id=1,
-            student=PermissionsStudent(id=1, user=User(id=1, name="William", nickname="Will")),
-            deployment=TestDeployment(
-                id=1,
-                duration_time=30,
-                open_at="2025-06-01T00:00:00",
-                close_at="2025-06-01T00:00:00",
-                generation=Generation(id=1, number=3, course=Course(id=1, name="프론트 초격차")),
-                test=Test(
-                    id=1,
-                    title="프론트엔드 기초 쪽지시험",
-                    subject=Subject(id=1, title="프론트엔드 기초"),
-                ),
-                questions_snapshot_json=[
-                    {
-                        "question_id": 1,
-                        "type": "multiple_choice_single",  # 객관식 단일 선택
-                        "question": "HTML의 기본 구조를 이루는 태그는?",
-                        "prompt": None,
-                        "blank_count": None,
-                        "options_json": ["A. <html>", "B. <head>", "C. <body>", "D. <div>"],
-                        "answer": ["A"],
-                        "point": 5,
-                        "explanation": "HTML 문서는 항상 <html> 태그로 시작하여 웹페이지의 전체 구조를 감쌉니다. 이 태그는 문서의 루트 요소로, <head>와 <body>를 포함합니다.",
-                    },
-                    {
-                        "question_id": 2,
-                        "type": "ox",  # ox 문제
-                        "question": "CSS는 프로그래밍 언어이다.",
-                        "prompt": None,
-                        "blank_count": None,
-                        "options_json": ["O", "X"],
-                        "answer": ["X"],
-                        "point": 5,
-                        "explanation": "CSS는 스타일을 정의하는 선언형 언어이며, 조건문이나 반복문과 같은 로직을 포함하지 않아 일반적으로 프로그래밍 언어로 분류되지 않습니다.",
-                    },
-                    {
-                        "question_id": 3,
-                        "type": "ordering",  # 순서 정렬
-                        "question": "다음 HTML 요소들을 웹 페이지에 표시되는 순서대로 정렬하세요.",
-                        "prompt": None,
-                        "blank_count": None,
-                        "options_json": ["<head>", "<html>", "<body>", "<title>"],
-                        "answer": ["<html>", "<head>", "<body>", "<title>"],
-                        "point": 10,
-                        "explanation": "HTML 문서는 <html> 태그로 시작하고, 그 안에 <head>와 <body>가 위치합니다. 일반적으로 <head>는 <body>보다 먼저 선언되며, <title>은 <head> 내부에 들어가므로 <html> → <head> → <body> → <title> 순서로 표시되면 안 되고, 구조상 <title>은 <head> 안에 먼저 위치해야 합니다. 정답은 문서 구조의 논리적 순서를 반영해야 합니다.",
-                    },
-                    {
-                        "question_id": 4,
-                        "type": "fill_in_blank",  # 빈칸 채우기
-                        "question": "다음 문장의 빈칸을 채우세요.",
-                        "prompt": "HTML에서 문서의 제목을 설정할 때 사용하는 태그는 <____>이다.",
-                        "blank_count": 1,
-                        "options_json": [],
-                        "answer": ["title"],
-                        "point": 5,
-                        "explanation": "<title> 태그는 웹 브라우저의 탭이나 검색 엔진 결과에 표시되는 문서의 제목을 정의하는 데 사용됩니다. 이 태그는 <head> 태그 내부에 위치해야 합니다.",
-                    },
-                    {
-                        "question_id": 5,
-                        "type": "short_answer",  # 주관식 단답형
-                        "question": "다음 문장의 빈칸을 채우세요.",
-                        "prompt": "HTML의 <____> 태그는 문서의 제목을 정의하고, <____> 태그 안에 위치한다.",
-                        "blank_count": 2,
-                        "options_json": [],
-                        "answer": ["<title>", "<head>"],
-                        "point": 5,
-                        "explanation": "color 속성은 HTML 요소의 텍스트 색상을 지정하는 데 사용됩니다. 예를 들어, color: red;는 텍스트 색상을 빨간색으로 설정합니다.",
-                    },
-                    {
-                        "question_id": 6,
-                        "type": "multiple_choice_multiple",  # 객관식 다중 선택
-                        "question": "다음 중 CSS에서 글자 색상과 관련된 속성을 모두 고르세요.",
-                        "prompt": None,
-                        "blank_count": None,
-                        "options_json": ["A. color", "B. background-color", "C. font-size", "D. text-align"],
-                        "answer": ["A", "B"],
-                        "point": 5,
-                        "explanation": "color는 글자 색상을 지정하고, background-color는 배경 색상을 지정합니다. font-size와 text-align은 각각 글자 크기와 정렬에 관한 속성입니다.",
-                    },
-                ],
-            ),
-            cheating_count=2,
-            created_at="2025-06-26T09:01:00",
-            updated_at="2025-06-26T09:31:00",
-            # 모델 필드에는 없음. 응답 JSON에만 포함
-            # score=30,           # 총 점수 추가
-            # correct_count=5,    # 정답 문제 수
-            # total_questions=6,  # 총 문제 수
-            # duration_minute=30, # 응시 소요 시간(분)
-            answers_json=[
-                {"question_id": 1, "type": "multiple_choice_single", "answer": ["A"]},
-                {"question_id": 2, "type": "ox", "answer": ["x"]},
-                {
-                    "question_id": 3,
-                    "type": "ordering",
-                    "answer": ["<html>", "<head>", "<body>", "<title>"],
-                },
-                {"question_id": 4, "type": "short_answer", "answer": ["title"]},
-                {"question_id": 5, "type": "fill_in_blank", "answer": [""]},
-                {"question_id": 6, "type": "multiple_choice_multiple", "answer": ["A", "B"]},
-            ],
+        test_submission = get_object_or_404(
+            TestSubmission.objects.select_related("student", "deployment__test"), pk=submission_id
         )
-        serializer = self.serializer_class(instance=mock_data)
+
+        serializer = self.serializer_class(instance=test_submission)
+
         return Response(
             {"message": "쪽지시험 응시내역 목록 상세 조회 완료", "data": serializer.data}, status=status.HTTP_200_OK
         )


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #
- 작업 요약: 관리자 쪽지시험 응시 내역 상세 조회 기능 구현
  1. 404 조회 예외 처리 추가
  2. 시리얼라이저 중복 정리
  3. 총점수, 정답 수, 총 문제 수, 소요 시간 계산 함수 추가
  4. grading.py 생성 및 채점 로직 분리
  5. 목록 조회 총점 반영 수정 (상세 조회에서 grading.py 생성하면서 같이 처리)

## 📄 상세 내용
- [x] 시리얼라이저 파일 수정:
    - tests/serializers/test.py  
    - tests/serializers/test_deployment.py  
    - tests/serializers/submission_serializers.py
- [x] tests/views/admin_testsumission_view.py 수정
- [x] core/utils/grading.py 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x]  Swagger 문서 작성 및 테스트 완료
- [x] 유효성 검사 테스트 완료
