### PR TITLE
feature/test_hotfixdetails_lsi ( 쪽지시험 상세조회 응답형식 수정)

### DIFF
--- a/apps/tests/serializers/test_serializers.py
+++ b/apps/tests/serializers/test_serializers.py
@@ -73,6 +73,7 @@ class TestQuestionSimpleSerializer(serializers.ModelSerializer["TestQuestion"]):
 # 쪽지시험 문제 단일 직렬화용
 class TestQuestionDetailSerializer(serializers.ModelSerializer):
     options = serializers.SerializerMethodField()
+    answer = serializers.SerializerMethodField()
 
     class Meta:
         model = TestQuestion
@@ -95,6 +96,18 @@ class TestQuestionDetailSerializer(serializers.ModelSerializer):
             except Exception:
                 return []
         return []
+
+    def get_answer(self, obj):
+        # array(string)로 내려야 하는 유형
+        if obj.type in {
+            TestQuestion.QuestionType.MULTIPLE_CHOICE_MULTI,
+            TestQuestion.QuestionType.ORDERING,
+            TestQuestion.QuestionType.FILL_IN_BLANK,
+        }:
+            answer = obj.answer
+            # 이미 리스트이면 그대로 반환, 아니면 단일 값이라도 리스트로 감쌈
+            return answer if isinstance(answer, list) else [answer]
+        return obj.answer  # string으로 유지
 
 
 # 쪽지시험 상세조회용 시리얼라이저


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 없음
- 작업 요약: 쪽지시험 상세조회 API에서 문제 유형에 따라 answer 응답 형식 수정

## 📄 상세 내용
- [x] multiple_choice_multi, ordering, fill_in_blank 유형의 answer을 string → array(string) 형식으로 직렬화되도록 수정
- [x] `TestQuestionDetailSerializer.get_answer()` 메서드 추가로 유형별 분기 처리
- [x] 나머지 문제 유형은 기존대로 string 유지, 응답 일관성 확보

## 📸 스크린샷 (선택)
- 없음

## 📝 기타 참고 사항
- 프론트에서 문제 유형별 정답 비교 시, 타입(string vs array) 일관성 부족으로 로직 처리에 불편함이 발생
- 해당 유형들은 복수 정답이 존재하거나 위치/순서가 중요한 구조이므로 array(string)으로 직렬화가 필요
- 이에 따라 백엔드에서 문제 유형 기준으로 answer 타입을 명확히 구분하여 응답 포맷 통일

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

