### PR TITLE
[Refactor/test submission result gej] wroks: 사용자 쪽지시험 제출 시 총점수와 맞은 문제 수 계산 및 저장 기능 추가

### DIFF
--- a/apps/tests/views/user_testsubmission_views.py
+++ b/apps/tests/views/user_testsubmission_views.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
@@ -7,6 +7,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.tests.core.utils.grading import (
+    calculate_correct_count,
+    calculate_total_score,
+    get_questions_snapshot_from_submission,
+    validate_answers_json_format,
+)
 from apps.tests.models import TestDeployment, TestSubmission
 from apps.tests.permissions import IsStudent
 from apps.tests.serializers.test_deployment_serializers import (
@@ -62,6 +68,25 @@ class TestStartView(APIView):
 @extend_schema(
     tags=["[User] Test - submission (쪽지시험 응시/제출/결과조회)"],
     request=UserTestSubmitSerializer,
+    examples=[
+        OpenApiExample(
+            name="쪽지시험 제출 예시",
+            value={
+                "student": 1,
+                "started_at": "2025-07-11T13:30:09.042Z",
+                "cheating_count": 1,
+                "answers_json": {
+                    "1": ["A"],
+                    "2": ["x"],
+                    "3": ["<html>", "<head>", "<body>", "<title>"],
+                    "4": ["title"],
+                    "5": ["<title>", "<head>"],
+                    "6": ["A", "B"],
+                },
+            },
+            request_only=True,
+        )
+    ],
 )
 class TestSubmissionSubmitView(APIView):
     permission_classes = [IsAuthenticated, IsStudent]
@@ -83,7 +108,14 @@ class TestSubmissionSubmitView(APIView):
             },
         )
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        submission = serializer.save()
+
+        snapshot = get_questions_snapshot_from_submission(submission)
+        validate_answers_json_format(submission.answers_json, snapshot)
+
+        submission.score = calculate_total_score(submission.answers_json, snapshot)
+        submission.correct_count = calculate_correct_count(submission.answers_json, snapshot)
+        submission.save(update_fields=["score", "correct_count"])
 
         # 자동 제출 메시지로 응답
         auto_msg = getattr(serializer, "auto_submit_message", None)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #
- 작업 요약: 사용자 쪽지시험 제출 시 총점수와 맞은 문제 수 계산 및 저장 기능 추가
  1. 쪽지시험 제출 시마다 문제 수 계산은 불필요하여, 시험 배포 생성 시 미리 계산해 저장하도록 변경 예정
 
## 📄 상세 내용
- [x] tests/views/user_testsubmission_views.py

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] Swagger 문서 작성 및 테스트 완료
