### PR TITLE
feature_hotfixcreate_lsi (문제 생성 시 options/answer 저장 및 응답 구조 개선, 전용 시리얼라이저 적용)

### DIFF
--- a/apps/tests/core/utils/question_validator.py
+++ b/apps/tests/core/utils/question_validator.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Callable
 
 from rest_framework.exceptions import ValidationError
@@ -18,6 +19,13 @@ class QuestionValidator:
         if answer[0] not in options:
             raise ValidationError(f"정답 '{answer[0]}'이 보기 목록에 없습니다.")
 
+        # 필수: 문자열 변환
+        data["options_json"] = json.dumps(options)
+
+        # 불필요 필드 제거
+        data["prompt"] = None
+        data["blank_count"] = None
+
         return data
 
     def validate_multiple_choice_multi_question(self, data: dict[str, Any]) -> dict[str, Any]:
@@ -33,6 +41,11 @@ class QuestionValidator:
         if invalid_answers:
             raise ValidationError(f"다음 정답은 보기 목록에 없습니다: {invalid_answers}")
 
+        data["prompt"] = None
+        data["blank_count"] = None
+
+        data["options_json"] = json.dumps(options)
+
         return data
 
     def validate_short_answer_question(self, data: dict[str, Any]) -> dict[str, Any]:
@@ -41,7 +54,7 @@ class QuestionValidator:
             raise ValidationError("주관식 단답형 문제는 정답을 하나만 담은 문자열 리스트 형식이어야 합니다.")
 
         data["options_json"] = None
-        data["prompt"] = None
+
         data["blank_count"] = None
 
         return data
@@ -61,6 +74,7 @@ class QuestionValidator:
 
         data["prompt"] = None
         data["blank_count"] = None
+        data["options_json"] = json.dumps(options)
 
         return data
 
@@ -97,9 +111,10 @@ class QuestionValidator:
             raise ValidationError("OX 퀴즈 정답은 'O' 또는 'X' 형식이어야 합니다.")
 
         # 필요 없는 필드 초기화
-        data["options_json"] = None
+
         data["prompt"] = None
         data["blank_count"] = None
+        data["options_json"] = json.dumps(data.get("options_json", ["O", "X"]))
 
         return data
 

--- a/apps/tests/serializers/test_question_serializers.py
+++ b/apps/tests/serializers/test_question_serializers.py
@@ -170,3 +170,43 @@ class TestQuestionSimpleSerializer(serializers.ModelSerializer):
     class Meta:
         model = TestQuestion
         fields = ["id", "question", "type", "point"]
+
+
+class TestQuestionCreateResponseSerializer(serializers.ModelSerializer):
+    """
+    [생성 응답 전용 시리얼라이저]
+
+    - 쪽지시험 문제 생성 후 클라이언트에게 반환할 응답 형식을 정의함
+    - 모델에는 options_json이 문자열(str)로 저장되어 있지만,
+      클라이언트에는 list 형식으로 반환되도록 가공함
+    - answer 역시 문제 유형에 따라 list or string으로 가공해 반환함
+    - 상세조회용 시리얼라이저와는 별도로, 생성 직후 응답 전용 출력 구조를 담당함
+    """
+
+    answer = serializers.SerializerMethodField()
+
+    class Meta:
+        model = TestQuestion
+        fields = (
+            "id",
+            "test",
+            "type",
+            "question",
+            "point",
+            "prompt",
+            "blank_count",
+            "options_json",
+            "answer",
+            "explanation",
+            "created_at",
+            "updated_at",
+        )
+
+    def get_answer(self, obj):
+        if obj.type in {
+            TestQuestion.QuestionType.MULTIPLE_CHOICE_MULTI,
+            TestQuestion.QuestionType.ORDERING,
+            TestQuestion.QuestionType.FILL_IN_BLANK,
+        }:
+            return obj.answer if isinstance(obj.answer, list) else [obj.answer]
+        return obj.answer

--- a/apps/tests/views/admin_testquestion_views.py
+++ b/apps/tests/views/admin_testquestion_views.py
@@ -12,6 +12,7 @@ from apps.tests.permissions import IsAdminOrStaff
 from apps.tests.serializers.test_question_serializers import (
     TestListItemSerializer,
     TestQuestionBulkCreateSerializer,
+    TestQuestionCreateResponseSerializer,
     TestQuestionCreateSerializer,
     TestQuestionSimpleSerializer,
     TestQuestionUpdateSerializer,
@@ -36,7 +37,7 @@ class TestQuestionCreateView(APIView):
         serializer = TestQuestionCreateSerializer(data=request.data)
         if serializer.is_valid():
             question = serializer.save()
-            return Response(TestQuestionCreateSerializer(question).data, status=status.HTTP_201_CREATED)
+            return Response(TestQuestionCreateResponseSerializer(question).data, status=201)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
@@ -111,6 +112,6 @@ class TestQuestionBulkUpdateAPIView(APIView):
         serializer.save()
         created_questions = serializer.create(serializer.validated_data)  # → bulk_create() 리턴값
 
-        response_data = TestQuestionSimpleSerializer(created_questions, many=True).data
+        response_data = TestQuestionCreateResponseSerializer(created_questions, many=True).data
 
         return Response(response_data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 없음
- 작업 요약: 문제 생성 시 options/answer 저장 및 응답 구조 개선, 전용 시리얼라이저 적용

---

## 📄 상세 내용

- [] 문제 생성 시 `options_json`이 정상 저장되지 않던 이슈 수정  
  - 일부 문제 유형에서 `options_json`, `prompt` 필드를 `None`으로 잘못 제거해 DB에 값이 저장되지 않던 문제 발생  
  - 문제 유형별 validator 로직에서 필요한 필드는 유지하고, 불필요한 필드만 명확히 제거하도록 수정  

- [] 상세조회 시 `options`가 빈 배열로 내려오던 문제 해결  
  - `TestQuestionDetailSerializer`에는 `options_json` → `options` 역직렬화 로직이 이미 구현되어 있었음  
  - 하지만 DB에 `options_json` 값이 저장되지 않아 항상 빈 리스트가 반환되던 문제였음  
  - bulk 생성 로직과 validator 수정으로 **정상 저장되도록 하여 조회 시에도 options가 보이게 됨**

- [] 응답 구조 개선을 위한 전용 시리얼라이저 `TestQuestionCreateResponseSerializer` 생성  

- [] bulk 생성 API에서도 동일한 응답 포맷(`TestQuestionCreateResponseSerializer`)으로 응답 통일  

- [] Swagger에서 사용할 수 있는 **모든 문제 유형이 포함된 bulk 요청 예시 JSON** 구성 완료  

---

## 📸 스크린샷 (선택)
없음

---

## 📝 기타 참고 사항
없음

---

## 🧪 PR Checklist
- [] 커밋 메시지 컨벤션에 맞게 작성했습니다  
- [] 모든 문제 유형에 대한 생성/조회 테스트를 완료했습니다  
- [] Swagger에서 bulk 테스트 요청 확인 완료했습니다  

